### PR TITLE
Fix eta_mini_batch tensor size annotation

### DIFF
--- a/ttt.py
+++ b/ttt.py
@@ -674,7 +674,7 @@ class TTTBase(nn.Module):
     def _init_ttt_lr_gate(self):
         # [width, 1]
         linear_weight_data = nn.Linear(self.width, 1, bias=True).weight.data
-        # prepending head dim -> [num_heads, width, 1]
+        # prepending head dim -> [num_heads, 1, width]
         self.learnable_ttt_lr_weight = nn.Parameter(
             torch.stack(
                 [torch.normal(0, 0.02, size=linear_weight_data.shape) for _ in range(self.num_heads)],


### PR DESCRIPTION
Currently, `eta_mini_batch` is annotated with `[B, nh, K, 1]` but this is incorrect and should be `[B, nh, K, K]`. In addition to this change, I added some more dimension comments in general to make the code easier to trace. This should resolve #33

Additionally,  `learnable_ttt_lr_weight` was described as `[num_heads, width, 1]` when in reality it is `[num_heads, 1, width]`